### PR TITLE
Add Mapbox tiled map proof of concept as a UI widget

### DIFF
--- a/Content/Levels/UI_TiledMap.umap
+++ b/Content/Levels/UI_TiledMap.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6cdcd8cfab9d2d45abbcaadda6bd5f8d7d2a9b6a4d2957af358447898c837617
+size 42419

--- a/Content/UI/TiledMap/TiledMap.uasset
+++ b/Content/UI/TiledMap/TiledMap.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7857312664f5a19f6794f25b2dc028a02da8332e357000a05edb27562b2fce39
+size 89823

--- a/Content/UI/WidgetTemplates/MapTile.uasset
+++ b/Content/UI/WidgetTemplates/MapTile.uasset
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e6cf84d0abdd8fbbeb5ea7bff44c4546df471532593898662141cec6b20b48f2
+size 39459


### PR DESCRIPTION
Add UI_TiledMap level that displays the proof of concept widget.
Add TiledMap asset that displays 9 MapTile widgets in a grid and call functions to load a satellite image for each one. 
Mapbox token is necessary and can be added in the TiledMap widget "Token" string variable.