### PR TITLE
Remove Extra Menu Toggle As it doesn't seem to be used and allows builds

### DIFF
--- a/Content/Levels/UI_Projects.umap
+++ b/Content/Levels/UI_Projects.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:8df67f6fe16100b3bacb2c326c04b8027acdc7ddbf00c19b07327855bafc2ced
-size 42513
+oid sha256:c54397f5cdbb8c90b8dc22ea756b7993dcbd7f8baecd8cdaa881dc0295a9ba46
+size 41626

--- a/Content/UI/WidgetTemplates/ExtraMenuToggle.uasset
+++ b/Content/UI/WidgetTemplates/ExtraMenuToggle.uasset
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:400d8fc5578fd1c7664a448c6b954745f80fc1682b7f5868c87f98b33a269b85
-size 274


### PR DESCRIPTION
The Extra Menu Toggle doesn't seem to be used and is what causes the build failures when looking at the logs. After removing this file the project builds and can run from the .exe

Not sure what the changes are to UI_Projects as it wouldn't let me undo them.
