### PR TITLE
Reset 3D view cursor

### DIFF
--- a/Content/UI/Toolbar/Toolbar.uasset
+++ b/Content/UI/Toolbar/Toolbar.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1c5bb3c18d835982d069194d48d3f153aea10a550e648b084df906a495f21564
-size 404799
+oid sha256:b77427c7244310a6a27a06987b2302389aeffc69b15bc1aaadbd3e1ed80c8ffd
+size 426346

--- a/Content/UI/WidgetTemplates/3DViewFrame.uasset
+++ b/Content/UI/WidgetTemplates/3DViewFrame.uasset
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4113e7d7fa2d510afce55b6c98b801750d14bc5d99a537f29ed8eb8a3e2b659c
-size 86402
+oid sha256:17d706c782248fc62c17ca943415c62c4ff1b1aad77419c56ac4db7bf3a04063
+size 95545


### PR DESCRIPTION
Fixes the following bugs:
- when the 3D view is closed the cursor stays in whatever mode it’s in e.g. adding annotation.
- if bounding box cursor mode is selected, selecting annotation cursor mode doesn’t clear the previous bounding box cursor. The same behaviour happens if selecting annotation then bounding.

New behaviour:
- the cursor resets its state before changing to a new mode or when the view is closed